### PR TITLE
仮想スティックの可動軸を指定できるAxisOptionsを追記

### DIFF
--- a/Assets/EnhancedOnScreenStick/Editor/EnhancedOnScreenStickEditor.cs
+++ b/Assets/EnhancedOnScreenStick/Editor/EnhancedOnScreenStickEditor.cs
@@ -19,6 +19,7 @@ namespace EnhancedOnScreenControls.Editor
             AddSpace(root, 6f);
 
             AddPropertyField(root, "stickType");
+            AddPropertyField(root, "axisOptions");
             AddPropertyField(root, "movementRange");
             AddPropertyField(root, "deadZone");
             AddPropertyField(root, "showOnlyWhenPressed");

--- a/Assets/EnhancedOnScreenStick/Runtime/EnhancedOnScreenStick.cs
+++ b/Assets/EnhancedOnScreenStick/Runtime/EnhancedOnScreenStick.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.InputSystem.Layouts;
@@ -13,6 +14,13 @@ namespace EnhancedOnScreenControls
         Dynamic = 2
     }
 
+    public enum AxisOptions
+    {
+        Both = 0,
+        Horizontal = 1,
+        Vertical = 2
+    }
+
     [AddComponentMenu("Input/Enhanced On-Screen Stick")]
     [RequireComponent(typeof(RectTransform))]
     public class EnhancedOnScreenStick : OnScreenControl, IPointerDownHandler, IPointerUpHandler, IDragHandler
@@ -23,6 +31,7 @@ namespace EnhancedOnScreenControls
         string internalControlPath;
 
         [SerializeField] StickType stickType;
+        [SerializeField] AxisOptions axisOptions = AxisOptions.Both;
         [SerializeField] float movementRange = 50f;
         [SerializeField, Range(0f, 1f)] float deadZone = 0f;
         [SerializeField] bool showOnlyWhenPressed;
@@ -91,7 +100,7 @@ namespace EnhancedOnScreenControls
             var camera = canvas.worldCamera;
             var position = RectTransformUtility.WorldToScreenPoint(camera, background.position);
 
-            var input = (eventData.position - position) / (movementRange * canvas.scaleFactor);
+            var input = (eventData.position - position) / (movementRange * canvas.scaleFactor) * EnabledAxis();
             var rawMagnitude = input.magnitude;
             var normalized = input.normalized;
 
@@ -118,6 +127,15 @@ namespace EnhancedOnScreenControls
                 return localPoint - (background.anchorMax * rectTransform.sizeDelta) + pivotOffset;
             }
             return Vector2.zero;
+        }
+
+        Vector2 EnabledAxis()
+        {
+            if (axisOptions == AxisOptions.Horizontal)
+                return Vector2.right;
+            else if (axisOptions == AxisOptions.Vertical)
+                return Vector2.up;
+            return Vector2.one;
         }
     }
 }


### PR DESCRIPTION
はじめまして、便利なライブラリなので使わせていただいております。
2Dプラットフォーマーゲームではキャラクターの横移動のみを扱う仮想スティックの需要もあるので、可動する軸を限定できたら便利だと思い、AxisOptionsを追加しました。
レビューをお願いします！
お気に召さなければ無視していただいて構いません！